### PR TITLE
Add completion time to submissions

### DIFF
--- a/client/src/pages/submissions.tsx
+++ b/client/src/pages/submissions.tsx
@@ -79,7 +79,7 @@ export default function Submissions() {
                     <div className="flex items-center gap-2 text-slate-300">
                       <Calendar className="h-4 w-4" />
                       <span className="text-sm">
-                        {format(new Date(submission.submittedAt), "MMM dd, yyyy")}
+                        {format(new Date(submission.submissionTime), "MMM dd, yyyy")}
                       </span>
                     </div>
                     <div className="flex items-center gap-2 text-slate-300">

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -45,8 +45,8 @@ export interface IStorage {
   
   // Submission operations
   createSubmission(submission: InsertSubmission): Promise<Submission>;
-  getUserSubmissions(userId: string): Promise<Submission[]>;
-  getChallengeSubmissions(challengeId: number, userId: string): Promise<Submission[]>;
+  getUserSubmissions(userId: string): Promise<(Submission & { challengeTitle: string | null; difficulty: string | null; completionTime: number | null; })[]>;
+  getChallengeSubmissions(challengeId: number, userId: string): Promise<(Submission & { challengeTitle: string | null; difficulty: string | null; completionTime: number | null; })[]>;
   
   // Tutorial progress operations
   getTutorialProgress(userId: string): Promise<TutorialProgress[]>;
@@ -160,18 +160,48 @@ export class DatabaseStorage implements IStorage {
     return submission;
   }
 
-  async getUserSubmissions(userId: string): Promise<Submission[]> {
+  async getUserSubmissions(userId: string): Promise<(Submission & { challengeTitle: string | null; difficulty: string | null; completionTime: number | null; })[]> {
     return await db
-      .select()
+      .select({
+        id: submissions.id,
+        userId: submissions.userId,
+        challengeId: submissions.challengeId,
+        battleId: submissions.battleId,
+        architecture: submissions.architecture,
+        status: submissions.status,
+        score: submissions.score,
+        feedback: submissions.feedback,
+        submissionTime: submissions.submissionTime,
+        challengeTitle: challenges.title,
+        difficulty: challenges.difficulty,
+        completionTime: battles.timeSpent,
+      })
       .from(submissions)
+      .leftJoin(challenges, eq(submissions.challengeId, challenges.id))
+      .leftJoin(battles, eq(submissions.battleId, battles.id))
       .where(eq(submissions.userId, userId))
       .orderBy(desc(submissions.submissionTime));
   }
 
-  async getChallengeSubmissions(challengeId: number, userId: string): Promise<Submission[]> {
+  async getChallengeSubmissions(challengeId: number, userId: string): Promise<(Submission & { challengeTitle: string | null; difficulty: string | null; completionTime: number | null; })[]> {
     return await db
-      .select()
+      .select({
+        id: submissions.id,
+        userId: submissions.userId,
+        challengeId: submissions.challengeId,
+        battleId: submissions.battleId,
+        architecture: submissions.architecture,
+        status: submissions.status,
+        score: submissions.score,
+        feedback: submissions.feedback,
+        submissionTime: submissions.submissionTime,
+        challengeTitle: challenges.title,
+        difficulty: challenges.difficulty,
+        completionTime: battles.timeSpent,
+      })
       .from(submissions)
+      .leftJoin(challenges, eq(submissions.challengeId, challenges.id))
+      .leftJoin(battles, eq(submissions.battleId, battles.id))
       .where(
         and(
           eq(submissions.challengeId, challengeId),


### PR DESCRIPTION
## Summary
- show `submissionTime` in submissions list
- include battle time when fetching submissions

## Testing
- `npm run check` *(fails: property errors in various TypeScript files)*

------
https://chatgpt.com/codex/tasks/task_e_68517542a1ec8331997a3bdfaea9b071