### PR TITLE
Add seeding script

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ REPLIT_CLIENT_SECRET=your_client_secret
 3. Initialize the database:
 ```bash
 npm run db:push
-npx tsx server/seed.ts   # optional
+npm run db:seed   # optional
 ```
 
 4. Start the development server:

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "db:seed": "tsx server/seed.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",


### PR DESCRIPTION
## Summary
- add `db:seed` script to package.json
- update README instructions to use the new script

## Testing
- `npm run check`
- `npm run db:seed` *(fails: DATABASE_URL must be set)*

------
https://chatgpt.com/codex/tasks/task_e_6851836e63f883319957a2babb76e500